### PR TITLE
Pattern Formatting

### DIFF
--- a/app/src/main/java/com/kitrady/InputHandler.java
+++ b/app/src/main/java/com/kitrady/InputHandler.java
@@ -81,7 +81,7 @@ public class InputHandler {
         return stRadius;
     }
 
-    public double getRowCircumference() {
+    public double getRdCircumference() {
         return rowCircumference;
     }
 

--- a/app/src/main/java/com/kitrady/PatternFormatter.java
+++ b/app/src/main/java/com/kitrady/PatternFormatter.java
@@ -1,51 +1,125 @@
 package com.kitrady;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 public class PatternFormatter {
-    private ArrayList<Integer> stitchesPerRow = new ArrayList<Integer>();
+    private ArrayList<Integer> stitchesPerRd = new ArrayList<Integer>();
     private ArrayList<String> formattedPattern = new ArrayList<String>();
 
-    public PatternFormatter(ArrayList<Integer> stitchesPerRow) {
-        this.stitchesPerRow = stitchesPerRow;
+    public PatternFormatter(ArrayList<Integer> stitchesPerRd) {
+        this.stitchesPerRd = stitchesPerRd;
     }
 
     private void formatPattern() {
-        formattedPattern.add("Rd 1: " + stitchesPerRow.getFirst() + " sc in magic ring (" + stitchesPerRow.getFirst() + ")");
+        // creates first round separately because of magic ring technique
+        formattedPattern.add("Rd 1: " + stitchesPerRd.getFirst() + " sc in magic ring (" + stitchesPerRd.getFirst() + ")");
 
-        for (int i = 1; i < stitchesPerRow.size(); i++) {
-            String currentRow = "Rd " + (i + 1) + ": ";
+        int FinalLargestRdIndex = stitchesPerRd.lastIndexOf(Collections.max(stitchesPerRd)); // finds last round that could need increases
+        formatIncreaseRounds(FinalLargestRdIndex);
+        formatDecreaseRounds(FinalLargestRdIndex);
+    }
 
-            int previousStTotal = stitchesPerRow.get(i - 1);
-            int currentStTotal = stitchesPerRow.get(i);
+    public void formatIncreaseRounds(int FinalLargestRdIndex) {
+        // loops to create each round of pattern that needs increases
+        for (int i = 1; i < FinalLargestRdIndex; i++) {
+            String currentRound = "Rd " + (i + 1) + ": "; // adds round number
+
+            int previousStTotal = stitchesPerRd.get(i - 1);
+            int currentStTotal = stitchesPerRd.get(i);
             int numIncreases = currentStTotal - previousStTotal;
 
-            if (numIncreases != 0) {
+            // checks if any increases are needed
+            if (numIncreases > 0) {
                 int numStitchesInRepeat = currentStTotal / numIncreases;
 
+                // if increases don't divide evenly into stitch total, calculates remaining stitches
                 int extraStitches = 0;
                 if (numStitchesInRepeat * numIncreases != currentStTotal) {
                     extraStitches = currentStTotal - (numStitchesInRepeat * numIncreases);
                 }
 
-                currentRow += "(" + (numStitchesInRepeat - 2) + "sc, inc) x" + numIncreases;
-
-                if (extraStitches != 0) {
-                    currentRow += ", " + extraStitches + " sc";
+                // checks if any single crochets are needed
+                if (numStitchesInRepeat - 2 > 0) {
+                    currentRound += "(" + (numStitchesInRepeat - 2) + "sc, inc) x" + numIncreases;
                 }
-            } else {
-                currentRow += "sc in each st in round";
+                // round is all increases if no single crochets are needed
+                else {
+                    currentRound += "inc in each st in round";
+                }
+
+                // adds extra stitches if there are any
+                if (extraStitches > 0) {
+                    currentRound += ", " + extraStitches + " sc";
+                }
+            }
+            // round is all single crochets if no increases are needed
+            else {
+                currentRound += "sc in each st in round";
             }
 
-            currentRow += " (" + currentStTotal + ")";
-            formattedPattern.add(currentRow);
+            // adds total stitch count to end
+            currentRound += " (" + currentStTotal + ")";
+
+            // adds the round to the collection of rounds
+            formattedPattern.add(currentRound);
         }
+    }
+
+    public void formatDecreaseRounds(int FinalLargestRdIndex) {
+        for (int i = FinalLargestRdIndex; i < stitchesPerRd.size(); i++) {
+            String currentRound = "Rd " + (i + 1) + ": "; // adds round number
+
+            int previousStTotal = stitchesPerRd.get(i - 1);
+            int currentStTotal = stitchesPerRd.get(i);
+            int numDecreases = previousStTotal - currentStTotal;
+
+            // checks if any decreases are needed
+            if (numDecreases > 0) {
+                int numStitchesInRepeat = previousStTotal / numDecreases;
+
+                // if decreases don't divide evenly into stitch total, calculates remaining stitches
+                int extraStitches = 0;
+                if (numStitchesInRepeat * numDecreases != previousStTotal) {
+                    extraStitches = previousStTotal - (numStitchesInRepeat * numDecreases);
+                }
+
+                // checks if any single crochets are needed
+                if (numStitchesInRepeat - 2 > 0) {
+                    currentRound += "(" + (numStitchesInRepeat - 2) + "sc, dec) x" + numDecreases;
+                }
+                // round is all decreases if no single crochets are needed
+                else {
+                    currentRound += "dec in each st in round";
+                }
+
+                // adds extra stitches if there are any
+                if (extraStitches > 0) {
+                    currentRound += ", " + extraStitches + " sc";
+                }
+            }
+            // round is all single crochets if no decreases are needed
+            else {
+                currentRound += "sc in each st in round";
+            }
+
+            // adds total stitch count to end
+            currentRound += " (" + currentStTotal + ")";
+
+            // adds the round to the collection of rounds
+            formattedPattern.add(currentRound);
+        }
+    }
+
+    public ArrayList<String> getFormattedPattern() {
+        formatPattern();
+        return formattedPattern;
     }
 
     public void printPattern() {
         formatPattern();
-        for (int i = 0; i < formattedPattern.size(); i++) {
-            System.out.print("\n" + formattedPattern.get(i));
+        for (String s : formattedPattern) {
+            System.out.print("\n" + s);
         }
     }
 }

--- a/app/src/main/java/com/kitrady/PatternFormatter.java
+++ b/app/src/main/java/com/kitrady/PatternFormatter.java
@@ -1,0 +1,51 @@
+package com.kitrady;
+
+import java.util.ArrayList;
+
+public class PatternFormatter {
+    private ArrayList<Integer> stitchesPerRow = new ArrayList<Integer>();
+    private ArrayList<String> formattedPattern = new ArrayList<String>();
+
+    public PatternFormatter(ArrayList<Integer> stitchesPerRow) {
+        this.stitchesPerRow = stitchesPerRow;
+    }
+
+    private void formatPattern() {
+        formattedPattern.add("Rd 1: " + stitchesPerRow.getFirst() + " sc in magic ring (" + stitchesPerRow.getFirst() + ")");
+
+        for (int i = 1; i < stitchesPerRow.size(); i++) {
+            String currentRow = "Rd " + (i + 1) + ": ";
+
+            int previousStTotal = stitchesPerRow.get(i - 1);
+            int currentStTotal = stitchesPerRow.get(i);
+            int numIncreases = currentStTotal - previousStTotal;
+
+            if (numIncreases != 0) {
+                int numStitchesInRepeat = currentStTotal / numIncreases;
+
+                int extraStitches = 0;
+                if (numStitchesInRepeat * numIncreases != currentStTotal) {
+                    extraStitches = currentStTotal - (numStitchesInRepeat * numIncreases);
+                }
+
+                currentRow += "(" + (numStitchesInRepeat - 2) + "sc, inc) x" + numIncreases;
+
+                if (extraStitches != 0) {
+                    currentRow += ", " + extraStitches + " sc";
+                }
+            } else {
+                currentRow += "sc in each st in round";
+            }
+
+            currentRow += " (" + currentStTotal + ")";
+            formattedPattern.add(currentRow);
+        }
+    }
+
+    public void printPattern() {
+        formatPattern();
+        for (int i = 0; i < formattedPattern.size(); i++) {
+            System.out.print("\n" + formattedPattern.get(i));
+        }
+    }
+}

--- a/app/src/main/java/com/kitrady/PatternRunner.java
+++ b/app/src/main/java/com/kitrady/PatternRunner.java
@@ -8,8 +8,8 @@ public class PatternRunner {
 
         InputHandler objInputHandler = new InputHandler(1.15, 4, 4);
 //        InputHandler objInputHandler = new InputHandler(input);
-        SphereMaker objSphereMaker = new SphereMaker(objInputHandler.getStRadius(), objInputHandler.getRowCircumference());
-        PatternFormatter objPatternFormatter =  new PatternFormatter(objSphereMaker.getStitchesPerRow());
+        SphereMaker objSphereMaker = new SphereMaker(objInputHandler.getStRadius(), objInputHandler.getRdCircumference());
+        PatternFormatter objPatternFormatter =  new PatternFormatter(objSphereMaker.getStitchesPerRd());
 
         System.out.println("\nobjInputGetter:" + objInputHandler);
         System.out.println("\nobjSphereMaker:" + objSphereMaker);

--- a/app/src/main/java/com/kitrady/PatternRunner.java
+++ b/app/src/main/java/com/kitrady/PatternRunner.java
@@ -9,10 +9,11 @@ public class PatternRunner {
         InputHandler objInputHandler = new InputHandler(1.15, 4, 4);
 //        InputHandler objInputHandler = new InputHandler(input);
         SphereMaker objSphereMaker = new SphereMaker(objInputHandler.getStRadius(), objInputHandler.getRowCircumference());
+        PatternFormatter objPatternFormatter =  new PatternFormatter(objSphereMaker.getStitchesPerRow());
 
         System.out.println("\nobjInputGetter:" + objInputHandler);
         System.out.println("\nobjSphereMaker:" + objSphereMaker);
 
-        objSphereMaker.printRows();
+        objPatternFormatter.printPattern();
     }
 }

--- a/app/src/main/java/com/kitrady/SphereMaker.java
+++ b/app/src/main/java/com/kitrady/SphereMaker.java
@@ -4,9 +4,7 @@ import java.util.ArrayList;
 import java.lang.Math;
 
 public class SphereMaker {
-    // array list where index represents row and value is number of stitches in row
-    ArrayList<Integer> stitchesPerRow = new ArrayList<Integer>();
-
+    private ArrayList<Integer> stitchesPerRow = new ArrayList<Integer>(); // array list where index represents row and value is number of stitches in row
     private final double stRadius;
     private final double rowCircumference;
     private final double degreesPerRow;
@@ -37,6 +35,11 @@ public class SphereMaker {
         for (int i = 0; i < originalSize; i++) {
             stitchesPerRow.add(stitchesPerRow.get(originalSize - i - 1));
         }
+    }
+
+    public ArrayList<Integer> getStitchesPerRow() {
+        generateRows();
+        return stitchesPerRow;
     }
 
     public void printRows() {

--- a/app/src/main/java/com/kitrady/SphereMaker.java
+++ b/app/src/main/java/com/kitrady/SphereMaker.java
@@ -4,54 +4,47 @@ import java.util.ArrayList;
 import java.lang.Math;
 
 public class SphereMaker {
-    private ArrayList<Integer> stitchesPerRow = new ArrayList<Integer>(); // array list where index represents row and value is number of stitches in row
+    private ArrayList<Integer> stitchesPerRd = new ArrayList<Integer>(); // array list where index represents round and value is number of stitches in round
     private final double stRadius;
     private final double rowCircumference;
-    private final double degreesPerRow;
+    private final double degreesPerRd;
 
     public SphereMaker(double stRadius, double rowCircumference) {
         this.stRadius = stRadius; // radius measured in stitches
         this.rowCircumference = rowCircumference;  // circumference measured in rows
-        degreesPerRow = 360.0 / rowCircumference; // divides 360 degrees in circumference by rows in circumference to get degrees per row
+        degreesPerRd = 360.0 / rowCircumference; // divides 360 degrees in circumference by rows in circumference to get degrees per row
     }
 
-    private void generateRows() {
-        // computes stitches per row, starting from top of sphere (aka 90 degrees) and ending at side of sphere (aka 0 degrees)
-        // uses degrees per row to increment angle properly
-        // no row can be at exact top, so starts with one row offset
+    private void generateRounds() {
+        // computes stitches per round, starting from top of sphere (aka 90 degrees) and ending at side of sphere (aka 0 degrees)
+        // uses degrees per round to increment angle properly
+        // no round can be at exact top, so starts with one round offset
         double angle;
-        for (angle = (90 - degreesPerRow); angle >= 0; angle -= degreesPerRow) {
-            double currentRadius = Math.cos(Math.toRadians(angle)) * stRadius; // finds radius associated with current row/angle using cosine
-            double currentCircumference = 6.2831 * currentRadius; // finds circumference associated with current row/angle using circumference formula
-            stitchesPerRow.add((int) Math.round(currentCircumference)); // expresses circumference as whole number of stitches and adds to list of stitches per row
+        for (angle = (90 - degreesPerRd); angle >= 0; angle -= degreesPerRd) {
+            double currentRadius = Math.cos(Math.toRadians(angle)) * stRadius; // finds radius associated with current round/angle using cosine
+            double currentCircumference = 6.2831 * currentRadius; // finds circumference associated with current round/angle using circumference formula
+            stitchesPerRd.add((int) Math.round(currentCircumference)); // expresses circumference as whole number of stitches and adds to list of stitches per round
         }
 
-        int originalSize = stitchesPerRow.size();
-        // if more than half of the angle increment was left, there is a "missing" row
-        if (angle + degreesPerRow >= degreesPerRow / 2) {
-            stitchesPerRow.add((int) Math.round(6.2831 * stRadius)); // adds "missing" row using an angle of zero, aka full radius
+        int originalSize = stitchesPerRd.size();
+        // if more than half of the angle increment was left, there is a "missing" round
+        if (angle + degreesPerRd >= degreesPerRd / 2) {
+            stitchesPerRd.add((int) Math.round(6.2831 * stRadius)); // adds "missing" round using an angle of zero, aka full radius
         }
         // since a sphere has identical hemispheres, reverse current stitch counts to get rest of sphere
         for (int i = 0; i < originalSize; i++) {
-            stitchesPerRow.add(stitchesPerRow.get(originalSize - i - 1));
+            stitchesPerRd.add(stitchesPerRd.get(originalSize - i - 1));
         }
     }
 
-    public ArrayList<Integer> getStitchesPerRow() {
-        generateRows();
-        return stitchesPerRow;
-    }
-
-    public void printRows() {
-        generateRows();
-        for (int i = 0; i < stitchesPerRow.size(); i++) {
-            System.out.print("\nRow " + (i + 1) + ": " + stitchesPerRow.get(i) + " stitches");
-        }
+    public ArrayList<Integer> getStitchesPerRd() {
+        generateRounds();
+        return stitchesPerRd;
     }
 
     public String toString() {
         return ("\n- Radius in stitches = " + stRadius +
                 "\n- Circumference in rows = " + rowCircumference +
-                "\n- Degrees per row = " + degreesPerRow);
+                "\n- Degrees per round = " + degreesPerRd);
     }
 }

--- a/app/src/test/java/com/kitrady/InputHandlerTest.java
+++ b/app/src/test/java/com/kitrady/InputHandlerTest.java
@@ -72,8 +72,8 @@ public class InputHandlerTest {
     }
 
     @Test
-    public void testRowCircumference() {
+    public void testRdCircumference() {
         InputHandler classUnderTest = new InputHandler(1.1, 4.7, 3.9);
-        assertEquals((6.2831 * 1.1 * 3.9), classUnderTest.getRowCircumference());
+        assertEquals((6.2831 * 1.1 * 3.9), classUnderTest.getRdCircumference());
     }
 }

--- a/app/src/test/java/com/kitrady/PatternFormatterTest.java
+++ b/app/src/test/java/com/kitrady/PatternFormatterTest.java
@@ -1,0 +1,63 @@
+package com.kitrady;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PatternFormatterTest {
+    @Test
+    public void patternFormatterTest1() {
+        ArrayList<Integer> stitchesPerRd = new ArrayList<>(List.of(6, 12, 18, 23, 26, 29, 31, 31, 31, 29, 26, 23, 18, 12, 6));
+        PatternFormatter objPatternFormatter =  new PatternFormatter(stitchesPerRd);
+        ArrayList<String> formattedPattern = objPatternFormatter.getFormattedPattern();
+        String output = "";
+        for (String s : formattedPattern) {
+            output += "\n" + s;
+        }
+        assertEquals("""
+
+Rd 1: 6 sc in magic ring (6)
+Rd 2: inc in each st in round (12)
+Rd 3: (1sc, inc) x6 (18)
+Rd 4: (2sc, inc) x5, 3 sc (23)
+Rd 5: (6sc, inc) x3, 2 sc (26)
+Rd 6: (7sc, inc) x3, 2 sc (29)
+Rd 7: (13sc, inc) x2, 1 sc (31)
+Rd 8: sc in each st in round (31)
+Rd 9: sc in each st in round (31)
+Rd 10: (13sc, dec) x2, 1 sc (29)
+Rd 11: (7sc, dec) x3, 2 sc (26)
+Rd 12: (6sc, dec) x3, 2 sc (23)
+Rd 13: (2sc, dec) x5, 3 sc (18)
+Rd 14: (1sc, dec) x6 (12)
+Rd 15: dec in each st in round (6)""", output);
+    }
+
+    @Test
+    public void patternFormatterTest2() {
+        ArrayList<Integer> stitchesPerRd = new ArrayList<>(List.of(6, 12, 18, 22, 26, 28, 29, 29, 28, 26, 22, 18, 12, 6));
+        PatternFormatter objPatternFormatter =  new PatternFormatter(stitchesPerRd);
+        ArrayList<String> formattedPattern = objPatternFormatter.getFormattedPattern();
+        String output = "";
+        for (String s : formattedPattern) {
+            output += "\n" + s;
+        }
+        assertEquals("""
+
+Rd 1: 6 sc in magic ring (6)
+Rd 2: inc in each st in round (12)
+Rd 3: (1sc, inc) x6 (18)
+Rd 4: (3sc, inc) x4, 2 sc (22)
+Rd 5: (4sc, inc) x4, 2 sc (26)
+Rd 6: (12sc, inc) x2 (28)
+Rd 7: (27sc, inc) x1 (29)
+Rd 8: sc in each st in round (29)
+Rd 9: (27sc, dec) x1 (28)
+Rd 10: (12sc, dec) x2 (26)
+Rd 11: (4sc, dec) x4, 2 sc (22)
+Rd 12: (3sc, dec) x4, 2 sc (18)
+Rd 13: (1sc, dec) x6 (12)
+Rd 14: dec in each st in round (6)""", output);
+    }
+}


### PR DESCRIPTION
Adds standard crochet pattern formatting

still needs to:
- use _sc, inc_ format instead of _(sc, inc) x1_
- distribute increases/decreases evenly instead of being lined up (if possible)